### PR TITLE
Allow UNKNOWN for old style snpEff EFF annotations

### DIFF
--- a/geneimpacts/__init__.py
+++ b/geneimpacts/__init__.py
@@ -1,3 +1,3 @@
 from .effect import Effect, SnpEff, VEP, OldSnpEff
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"

--- a/geneimpacts/effect.py
+++ b/geneimpacts/effect.py
@@ -164,6 +164,8 @@ IMPACT_SEVERITY = [
 
     ('?', 'UNKNOWN'),  # some VEP annotations have '?'
     ('', 'UNKNOWN'),  # some VEP annotations have ''
+    ('UNKNOWN', 'UNKNOWN'),  # some snpEFF annotations have 'unknown'
+
 
 ]
 
@@ -587,10 +589,25 @@ class OldSnpEff(SnpEff):
         try:
             return max(lookup[old_snpeff_lookup[csq]] for csq in self.consequences)
         except KeyError:
-            #in between
-            sevs = [IMPACT_SEVERITY.get(csq, "LOW") for csq in self.consequences]
-            return max(lookup[s] for s in sevs)
+            try:
+                #in between
+                sevs = [IMPACT_SEVERITY.get(csq, "LOW") for csq in self.consequences]
+                return max(lookup[s] for s in sevs)
+            except KeyError:
+                return Effect.severity.fget(self)
 
+
+    """
+    @property
+    def severity(self, lookup={'HIGH': 3, 'MED': 2, 'LOW': 1, 'UNKNOWN': 0}, sev=IMPACT_SEVERITY):
+        # higher is more severe. used for ordering.
+        v = max(lookup[sev[csq]] for csq in self.consequences)
+        if v == 0:
+            sys.stderr.write("unknown severity for '%s'. using LOW\n" %
+                    self.effect_string)
+            v = 1
+        return v
+    """
     @property
     def transcript(self):
         if 'Transcript' in self.effects:

--- a/geneimpacts/effect.py
+++ b/geneimpacts/effect.py
@@ -582,7 +582,7 @@ class OldSnpEff(SnpEff):
             return list(it.chain.from_iterable(x.split("+") for x in self.effects['Effect'].split('&')))
 
     @property
-    def severity(self, lookup={'HIGH': 3, 'MED': 2, 'LOW': 1}):
+    def severity(self, lookup={'HIGH': 3, 'MED': 2, 'LOW': 1, 'UNKNOWN': 0}):
         # higher is more severe. used for ordering.
         try:
             return max(lookup[old_snpeff_lookup[csq]] for csq in self.consequences)

--- a/geneimpacts/tests/test_impacts.py
+++ b/geneimpacts/tests/test_impacts.py
@@ -206,3 +206,10 @@ def test_weird_vep():
             v = VEP(c, keys)
             assert v.impact_severity in ('LOW', 'MEDIUM', 'HIGH')
 
+def test_empty_snpeff():
+
+    keys = [x.strip() for x in 'Effect | Effect_Impact | Functional_Class | Codon_Change | Amino_Acid_change| Amino_Acid_length | Gene_Name | Transcript_BioType | Gene_Coding | Transcript_ID | Exon_Rank  | Genotype_Number  | ERRORS | WARNINGS'.split("|")]
+
+    eff = "(MODIFIER||||||||||A|ERROR_CHROMOSOME_NOT_FOUND)"
+    v = OldSnpEff(eff, keys)
+    assert v.impact_severity == "LOW", v.impact_severity


### PR DESCRIPTION
Brent;
This is a small fix for older EFF annotations with unknown severity. I should move to new style ANN annotations for our work in bcbio now that geneimpacts and GEMINI support them but wanted to get this fix in for anyone else using EFF.