### PR TITLE
snpEff: old EFF UNKNOWN and new ANN impact

### DIFF
--- a/geneimpacts/effect.py
+++ b/geneimpacts/effect.py
@@ -585,7 +585,7 @@ class OldSnpEff(SnpEff):
             return list(it.chain.from_iterable(x.split("+") for x in self.effects['Effect'].split('&')))
 
     @property
-    def severity(self, lookup={'HIGH': 3, 'MED': 2, 'LOW': 1, 'UNKNOWN': 0}):
+    def severity(self, lookup={'HIGH': 3, 'MED': 2, 'LOW': 1}):
         # higher is more severe. used for ordering.
         try:
             return max(lookup[old_snpeff_lookup[csq]] for csq in self.consequences)

--- a/geneimpacts/effect.py
+++ b/geneimpacts/effect.py
@@ -96,6 +96,7 @@ IMPACT_SEVERITY = [
     ('exon_loss_variant', 'HIGH'), # snpEff
     ('exon_loss', 'HIGH'), # snpEff
     ('rare_amino_acid_variant', 'HIGH'),
+    ('protein_protein_contact', 'HIGH'), # snpEff
     ('splice_acceptor_variant', 'HIGH'), # VEP
     ('splice_donor_variant', 'HIGH'), # VEP
     ('stop_gained', 'HIGH'), # VEP
@@ -584,7 +585,7 @@ class OldSnpEff(SnpEff):
             return list(it.chain.from_iterable(x.split("+") for x in self.effects['Effect'].split('&')))
 
     @property
-    def severity(self, lookup={'HIGH': 3, 'MED': 2, 'LOW': 1}):
+    def severity(self, lookup={'HIGH': 3, 'MED': 2, 'LOW': 1, 'UNKNOWN': 0}):
         # higher is more severe. used for ordering.
         try:
             return max(lookup[old_snpeff_lookup[csq]] for csq in self.consequences)


### PR DESCRIPTION
- Fixes older EFF annotations with unknown severity
- Adds `protein_protein_contact` in new snpEff ANN annotations
(https://github.com/pcingola/SnpEff/blob/539115b3ba29fec35104f672ba6adeb0397789ab/src/main/java/org/snpeff/snpEffect/EffectType.java#L450)
which is a HIGH impact change (https://github.com/pcingola/SnpEff/blob/539115b3ba29fec35104f672ba6adeb0397789ab/src/main/java/org/snpeff/snpEffect/EffectType.java#L39).