### PR TITLE
Support for new effect types in snpEff 4.3

### DIFF
--- a/geneimpacts/__init__.py
+++ b/geneimpacts/__init__.py
@@ -1,3 +1,3 @@
 from .effect import Effect, SnpEff, VEP, OldSnpEff
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/geneimpacts/effect.py
+++ b/geneimpacts/effect.py
@@ -98,6 +98,8 @@ IMPACT_SEVERITY = [
     ('exon_loss', 'HIGH'), # snpEff
     ('rare_amino_acid_variant', 'HIGH'),
     ('protein_protein_contact', 'HIGH'), # snpEff
+    ('structural_interaction_variant', 'HIGH'), #snpEff
+    ('feature_fusion', 'HIGH'), #snpEff
     ('splice_acceptor_variant', 'HIGH'), # VEP
     ('splice_donor_variant', 'HIGH'), # VEP
     ('stop_gained', 'HIGH'), # VEP
@@ -108,7 +110,9 @@ IMPACT_SEVERITY = [
 
 
     ('disruptive_inframe_deletion', 'MED'), #snpEff
+    ('conservative_inframe_deletion', 'MED'), #snpEff
     ('disruptive_inframe_insertion', 'MED'), #snpEff
+    ('conservative_inframe_insertion', 'MED'), #snpEff
     ('inframe_insertion', 'MED'), # VEP
     ('inframe_deletion', 'MED'), # VEP
     ('missense_variant', 'MED'), # VEP


### PR DESCRIPTION
snpEff 4.3 is due out soon and has a lot of improvements for structural
variation annotation we're using in bcbio. This adds support for a few
new effect types present in 4.3

- inframe_insersion/deletion -- now prefixed with conservative

  https://github.com/pcingola/SnpEff/commit/7727dd92a91345559fa873cc95e8bb18df835e84#diff-0315e7e23ec67c4ac01e90587e215319R353

- structural_interaction_variant

  https://github.com/pcingola/SnpEff/commit/18ad192f751d2e34595949dda8b25c295c8a9ca1#diff-0315e7e23ec67c4ac01e90587e215319R456

- feature_fusion

  https://github.com/pcingola/SnpEff/commit/facf8c58fc07a167706b90f6a263d037faa58862#diff-0315e7e23ec67c4ac01e90587e215319R396