### PR TITLE
Fix SnpEff exonic property

### DIFF
--- a/geneimpacts/effect.py
+++ b/geneimpacts/effect.py
@@ -590,7 +590,7 @@ class SnpEff(Effect):
 
     @property
     def exonic(self):
-        csqs = self.consequence
+        csqs = self.consequences
         if isinstance(csqs, basestring):
             csqs = [csqs]
         return any(csq in EXONIC_IMPACTS for csq in csqs) and self.effects['Transcript_BioType'] == 'protein_coding'


### PR DESCRIPTION
A Gemini user on usegalaxy.eu reported yesterday that gemini's is_exonic column is wrongly populated for SnpEff-annotated composite effects.
I think this simple typo here is the reason.