### PR TITLE
change MEDIUM to MODERATE (SnpEff impact) in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ severity
 --------
 
 Severity is based on the [impacts from VEP](http://uswest.ensembl.org/info/docs/tools/vep/script/vep_other.html#pick)
-and the [impacts from snpEff](http://snpeff.sourceforge.net/VCFannotationformat_v1.0.pdf). We reduce from the 4 categories HIGH, MEDIUM, LOW, MODIFIER to 3 by renaming MEDIUM to MED and renaming MODIFIER to LOW.
+and the [impacts from snpEff](http://snpeff.sourceforge.net/VCFannotationformat_v1.0.pdf). We reduce from the 4 categories HIGH, MODERATE, LOW, MODIFIER to 3 by renaming MODERATE to MED and renaming MODIFIER to LOW.


### PR DESCRIPTION
This is a quick update to the README to accurately reflect the possible SnpEff annotation impact values.

From what I'm seeing, SnpEff itself uses `HIGH`, **`MODERATE`**, `LOW`, and `MODIFIER`... but if I'm wrong or missing something, let me know and/or close this PR. Thanks!