### PR TITLE
Modified effect.py to add new vep splice region annotations, accordin…

### DIFF
--- a/geneimpacts/effect.py
+++ b/geneimpacts/effect.py
@@ -125,7 +125,10 @@ IMPACT_SEVERITY = [
     ('regulatory_region_ablation', 'MED'), # VEP
 
     ('5_prime_UTR_truncation', 'MED'), # found in snpEff
+    ('splice_donor_5th_base_variant', 'MED'), # VEP changed to have medium priority
     ('splice_region_variant', 'MED'), # VEP changed to have medium priority
+    ('splice_donor_region_variant', 'MED'), # VEP changed to have medium priority
+    ('splice_polypyrimidine_tract_variant', 'MED'), # VEP changed to have medium priority
 
     ('3_prime_UTR_truncation', 'LOW'), # found in snpEff
     ('non_canonical_start_codon', 'LOW'), # found in snpEff


### PR DESCRIPTION
…g to https://useast.ensembl.org/info/genome/variation/prediction/predicted_data.html

As of vep105, three new annotations were added, i.e., 

https://useast.ensembl.org/info/docs/tools/vep/script/vep_download.html#history

> 3 new Sequence Ontology terms are reported for more detailed splice consequence annotation
> splice_donor_5th_base_variant ([SO:0001787](http://www.sequenceontology.org/miso/current_release/term/SO:0001787))
> splice_donor_region_variant ([SO:0002170](http://www.sequenceontology.org/miso/current_release/term/SO:0002170))
> splice_polypyrimidine_tract_variant ([SO:0002169](http://www.sequenceontology.org/miso/current_release/term/SO:0002169))

I tested these changes locally using a VCF annotated by vep108 and it works for me in vcfanno + vcf2db.

See also related issue here: https://github.com/arq5x/gemini/issues/926

Let me know if any questions.

Thanks, 
Andrew